### PR TITLE
Set slot id for correct replacement on AJAX request

### DIFF
--- a/src/Resources/views/storefront/narrative/element/cms-element-product-listing.html.twig
+++ b/src/Resources/views/storefront/narrative/element/cms-element-product-listing.html.twig
@@ -38,6 +38,10 @@ uses a loop through Boxalino response blocks (block.blocks) to render the other 
         {% set params = {search: page.searchTerm } %}
     {% endif %}
 
+    {% if element %}
+        {% set params = {slots: element.id} %}
+    {% endif %}
+    
     {% block element_product_listing_wrapper %}
         <div class="cms-element-product-listing-wrapper"
              data-listing-pagination="true"

--- a/src/Resources/views/storefront/narrative/element/cms-element-sidebar-filter.html.twig
+++ b/src/Resources/views/storefront/narrative/element/cms-element-sidebar-filter.html.twig
@@ -27,6 +27,10 @@ If you wish the default Shopware6 facets feature (facets to be constant) - use d
     {% set params = {search: page.searchTerm } %}
 {% endif %}
 
+{% if element %}
+    {% set params = {slots: element.id} %}
+{% endif %}
+
 {% block element_filter_listing_wrapper %}
     <div class="cms-element-product-listing-wrapper"
          data-listing="true"


### PR DESCRIPTION
The slot ID needs to be set, so shopware only returns the HTML of the listing and filter-panel, and not the rest of the page on e.g. filter changing.